### PR TITLE
Added colon-separated time strings and updated URL

### DIFF
--- a/org-clock-split.el
+++ b/org-clock-split.el
@@ -2,7 +2,7 @@
 
 ;; Author: Justin Taft <https://github.com/justintaft>
 ;; Keywords: calendar
-;; URL: https://github.com/justintaft/emacs-org-clock-split
+;; URL: https://github.com/justintaft/org-clock-split
 ;; Version: 1.0
 ;; Package-Requires: ((emacs "24"))
 


### PR DESCRIPTION
Some parts of org-mode use colon-separated times, for example setting effort or scheduling a task at a specific time. I added support for colon-separated times.

Happy to iterate and improve.